### PR TITLE
Improve cmd

### DIFF
--- a/cmd/ta/main.go
+++ b/cmd/ta/main.go
@@ -123,11 +123,7 @@ var searchBytes = []byte("RDDLRDDLRDDLRDDLRDDLRDDLRDDLRDDL")
 
 func attestTAPublicKeyHex(pubHexString string) error {
 	ta := "'{\"pubkey\": \"" + pubHexString + "\"}'"
-	commandStr := planetmintGo + " tx machine register-trust-anchor " + ta
-	commandStr = commandStr + " --from " + planetmintAddress
-	commandStr = commandStr + " -y --gas-prices 0.000005plmnt --gas 200000"
-	fmt.Println("Command: " + commandStr)
-	cmd := exec.Command("bash", "-c", commandStr)
+	cmd := exec.Command(planetmintGo, "tx", "machine", "register-trust-anchor", ta, "--from", planetmintAddress, "-y", "--fees", "1plmnt")
 	out, err := cmd.Output()
 	if err != nil {
 		// if there was any error, print it here

--- a/cmd/ta/main.go
+++ b/cmd/ta/main.go
@@ -59,7 +59,6 @@ func LoadConfig(path string) (v *viper.Viper, err error) {
 
 var planetmintAddress string
 var planetmintGo string
-var planetmintKeyring string
 
 func toInt(bytes []byte, offset int) int {
 	result := 0
@@ -127,9 +126,6 @@ func attestTAPublicKeyHex(pubHexString string) error {
 	commandStr := planetmintGo + " tx machine register-trust-anchor " + ta
 	commandStr = commandStr + " --from " + planetmintAddress
 	commandStr = commandStr + " -y --gas-prices 0.000005plmnt --gas 200000"
-	if planetmintKeyring != "" {
-		commandStr = commandStr + " --keyring-backend " + planetmintKeyring
-	}
 	fmt.Println("Command: " + commandStr)
 	cmd := exec.Command("bash", "-c", commandStr)
 	out, err := cmd.Output()
@@ -260,7 +256,6 @@ func main() {
 	if err != nil || planetmintAddress == "" || planetmintGo == "" {
 		panic("couldn't read configuration")
 	}
-	planetmintKeyring = config.GetString("PLANETMINT_KEYRING")
 	fmt.Printf("global config %s\n", planetmintAddress)
 	loadFirmwares(config)
 	err = startWebService(config)

--- a/config/config.go
+++ b/config/config.go
@@ -7,20 +7,18 @@ FIRMWARE_ESP32={{ .FirmwareESP32 }}
 FIRMWARE_ESP32C3={{ .FirmwareESP32C3 }}
 PLANETMINT_ACTOR={{ .PlanetmintActor }}
 PLANETMINT_GO={{ .PlanetmintGo }}
-PLANETMINT_KEYRING={{ .PlanetmintKeyring }}
 SERVICE_BIND={{ .ServiceBind }}
 SERVICE_PORT={{ .ServicePort }}
 `
 
 // Config defines TA's top level configuration
 type Config struct {
-	FirmwareESP32     string `mapstructure:"firmware-esp32" json:"firmware-esp32"`
-	FirmwareESP32C3   string `mapstructure:"firmware-esp32c3" json:"firmware-esp32c3"`
-	PlanetmintActor   string `mapstructure:"planetmint-actor" json:"planetmint-actor"`
-	PlanetmintGo      string `mapstructure:"planetmint-go" json:"planetmint-go"`
-	PlanetmintKeyring string `mapstructure:"planetmint-keyring" json:"planetmint-keyring"`
-	ServiceBind       string `mapstructure:"service-bind" json:"service-bind"`
-	ServicePort       int    `mapstructure:"service-port" json:"service-port"`
+	FirmwareESP32   string `mapstructure:"firmware-esp32" json:"firmware-esp32"`
+	FirmwareESP32C3 string `mapstructure:"firmware-esp32c3" json:"firmware-esp32c3"`
+	PlanetmintActor string `mapstructure:"planetmint-actor" json:"planetmint-actor"`
+	PlanetmintGo    string `mapstructure:"planetmint-go" json:"planetmint-go"`
+	ServiceBind     string `mapstructure:"service-bind" json:"service-bind"`
+	ServicePort     int    `mapstructure:"service-port" json:"service-port"`
 }
 
 // global singleton
@@ -32,13 +30,12 @@ var (
 // DefaultConfig returns TA's default configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		FirmwareESP32:     "./tasmota32-rddl.bin",
-		FirmwareESP32C3:   "./tasmota32c3-rddl.bin",
-		PlanetmintActor:   "plmnt15xuq0yfxtd70l7jzr5hg722sxzcqqdcr8ptpl5",
-		PlanetmintGo:      "planetmint-god",
-		PlanetmintKeyring: "", // optional
-		ServiceBind:       "localhost",
-		ServicePort:       8080,
+		FirmwareESP32:   "./tasmota32-rddl.bin",
+		FirmwareESP32C3: "./tasmota32c3-rddl.bin",
+		PlanetmintActor: "plmnt15xuq0yfxtd70l7jzr5hg722sxzcqqdcr8ptpl5",
+		PlanetmintGo:    "planetmint-god",
+		ServiceBind:     "localhost",
+		ServicePort:     8080,
 	}
 }
 


### PR DESCRIPTION
- Avoid exec.Command("bash", "-c", ...)

- Remove PLANETMINT_KEYRING

Use the default set in `client.toml`.